### PR TITLE
Get table name dynamically

### DIFF
--- a/app/code/community/SomethingDigital/RemoveSymlinkConfig/sql/sd_removesymlinkconfig_setup/mysql4-install-0.1.0.php
+++ b/app/code/community/SomethingDigital/RemoveSymlinkConfig/sql/sd_removesymlinkconfig_setup/mysql4-install-0.1.0.php
@@ -1,5 +1,5 @@
 <?php
 $installer = $this;
 $installer->startSetup();
-$installer->run("delete from core_config_data where path='dev/template/allow_symlink'");
+$installer->run("delete from " . $installer->getTable('core_config_data') . " where path='dev/template/allow_symlink'");
 $installer->endSetup();


### PR DESCRIPTION
Use `$installer->getTable()` to get table name with prefix if it's used.